### PR TITLE
Modify dimensions value parser, and Use urfave/cli version 1.

### DIFF
--- a/Gomfile
+++ b/Gomfile
@@ -1,2 +1,2 @@
-gom 'github.com/urfave/cli', :tag => 'v1.19.1'
+gom 'gopkg.in/urfave/cli.v1', :tag => 'v1.22.3'
 gom 'github.com/aws/aws-sdk-go', :tag => 'v1.5.13'

--- a/lib/utils.go
+++ b/lib/utils.go
@@ -77,7 +77,7 @@ func BuildParams(input BuildParamsInput) *cloudwatch.GetMetricStatisticsInput {
 
 			s[i] = &cloudwatch.Dimension{
 				Name:  aws.String(splitted[0]),
-				Value: aws.String(splitted[1]),
+				Value: aws.String(strings.Join(splitted[1:], ":")),
 			}
 		}
 

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/y13i/metrin/lib"
 
-	"github.com/urfave/cli"
+	"gopkg.in/urfave/cli.v1"
 )
 
 const (


### PR DESCRIPTION
# PR Summary

1. Modify dimensions value parser
1. Explicitly use urfave/cli version 1.

## Modify dimensions value parser

Enabled parsing correctly when using Amazon Resource Name (ARN) for dimension value.
e.g.  AWS Shield Advanced metrics `DDoSDetected`

ref: https://docs.aws.amazon.com/waf/latest/developerguide/monitoring-cloudwatch.html

## Explicitly use urfave/cli version 1.

`urfave/cli` is now incompatible with version upgrade, so v1 is explicitly imported.




